### PR TITLE
Cap efficiency for otherfossil at 45%

### DIFF
--- a/pommesdata/data_preparation.ipynb
+++ b/pommesdata/data_preparation.ipynb
@@ -1757,8 +1757,11 @@
     "conv_de_new.drop(columns=['efficiency_data', 'efficiency_source', 'efficiency_estimate'], \n",
     "                 inplace=True)\n",
     "\n",
-    "# Cap efficiency for lignite plants given unrealistically high values\n",
-    "conv_de.loc[(conv_de.fuel == \"lignite\") & (conv_de.efficiency_el > 0.45), \"efficiency_el\"] = 0.45"
+    "# Cap efficiency for lignite plants and otherfossil given unrealistically high values\n",
+    "efficiency_cap = 0.45\n",
+    "conv_de.loc[\n",
+    "    (conv_de.fuel.isin([\"lignite\", \"otherfossil\"])) \n",
+    "    & (conv_de.efficiency_el > efficiency_cap), \"efficiency_el\"] = efficiency_cap"
    ]
   },
   {


### PR DESCRIPTION
Introduce a cap for otherfossil efficiency at 45% in order to correct data errors (same as for lignite).