### PR TITLE
Extend investment expenses time series up to 2100

### DIFF
--- a/pommesdata/data_prep/tools.py
+++ b/pommesdata/data_prep/tools.py
@@ -736,6 +736,7 @@ def combine_parameter_estimates(
     proxies=None,
     transform=False,
     save=True,
+    inflation_rate=1.02,
 ):
     """Re-combine parameter estimates
 
@@ -768,6 +769,9 @@ def combine_parameter_estimates(
     save: boolean
         If True, save to disk
 
+    inflation_rate: float
+        Inflation rate to apply when appending data set
+
     Returns
     -------
     overall_data_set: pd.DataFrame
@@ -798,6 +802,14 @@ def combine_parameter_estimates(
             overall_data_set.loc[missing_tech_fuel] = overall_data_set.loc[
                 tech_fuel_proxy
             ]
+
+    # Data needs to be appended at the end
+    if not isinstance(col_names[-1], str):
+        if col_names[-1] > 2050:
+            for iter_year in range(2050, col_names[-1] + 1):
+                overall_data_set.loc[pd.to_datetime(f"{iter_year}-01-01")] = (
+                    overall_data_set.loc[pd.to_datetime(f"2050-01-01")]
+                ) * inflation_rate ** (iter_year - 2050)
 
     if save:
         overall_data_set.to_csv(f"{path}{parameter}_{estimate}_nominal.csv")

--- a/pommesdata/data_preparation.ipynb
+++ b/pommesdata/data_preparation.ipynb
@@ -9700,14 +9700,15 @@
     "for number, data_sets in enumerate(list_of_data_sets):\n",
     "    for estimate in [\"5%\", \"50%\", \"95%\"]:\n",
     "        overall_data_set = tools.combine_parameter_estimates(\n",
-    "            col_names=list(range(2020, 2051)),\n",
+    "            col_names=list(range(2020, 2101)),\n",
     "            data_sets=data_sets,\n",
     "            parameter=iterations[number][\"parameter\"],\n",
     "            estimate=estimate,\n",
     "            path=main_path[\"outputs\"],\n",
     "            transform=True,\n",
     "            save=True,\n",
-    "            proxies=proxies[number]\n",
+    "            proxies=proxies[number],\n",
+    "            inflation_rate=inflation_rate,\n",
     "        )"
    ]
   },

--- a/raw_data_input/storages/storages_el_investment_options.csv
+++ b/raw_data_input/storages/storages_el_investment_options.csv
@@ -1,3 +1,3 @@
 plant;country;type;bus_inflow;bus_outflow;loss_rate;efficiency_pump;efficiency_turbine;initial_storage_level;min_storage_level;max_storage_level;min_invest_pump;max_invest_pump;overall_invest_limit_pump;min_invest_turbine;max_invest_turbine;overall_invest_limit_turbine;min_invest;max_invest;overall_invest_limit;unit_lifetime_pump;unit_lifetime_turbine;unit_lifetime;invest_relation_input_output;invest_relation_input_capacity;invest_relation_output_capacity;bus_technology
-DE_storage_el_PHS_new_built;DE;phes;DE_bus_el;DE_bus_el;0.01;0.82;0.89;0.5;0;1;0;800;800;0;800;800;0;800;800;45;45;80;1;;;storage_el_PHS
+DE_storage_el_PHS_new_built;DE;phes;DE_bus_el;DE_bus_el;0.01;0.82;0.89;0.5;0;1;0;800;800;0;800;800;0;800;800;45;45;50;1;;;storage_el_PHS
 DE_storage_el_battery_new_built;DE;battery;DE_bus_el;DE_bus_el;0.01;0.98;0.98;0;0;1;0;7000;1000000;0;7000;1000000;0;21000;3000000;15;15;15;1;0.33;;storage_el_battery


### PR DESCRIPTION
* Use inflationated values from 2050 until 2100 onwards.
* Extended time series are only needed to derive fixed costs as percentage shares of investment.