### PR TITLE
Write out unclustered transformers data

### DIFF
--- a/pommesdata/data_preparation.ipynb
+++ b/pommesdata/data_preparation.ipynb
@@ -6666,7 +6666,12 @@
     "    choices = [0, 0]\n",
     "    all_conv_de_clustered[capacity_col] = np.select(\n",
     "        conditions, choices, default=all_conv_de_clustered[\"capacity\"]\n",
-    "    )"
+    "    )\n",
+    "    \n",
+    "# Write unclustered data\n",
+    "all_conv_de_clustered.to_csv(\n",
+    "    f\"{main_path['outputs']}{output_file['transformers_exogenous']}_unclustered.csv\"\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
As title states, unclustered transformers data is written out before being grouped to clusters.