### PR TITLE
Handle shortage capacities for Italy

### DIFF
--- a/pommesdata/data_preparation.ipynb
+++ b/pommesdata/data_preparation.ipynb
@@ -8033,7 +8033,7 @@
     "tags": []
    },
    "source": [
-    "## Perform residualload analysis to obtain capacity deficits\n",
+    "## Perform residual load analysis to obtain capacity deficits\n",
     "* The external capacities taken from ENTSO-E's TYNDP neglect the fact that imports from outside the covered area are an option.\n",
     "* Also, the demand development modelled is not perfectly in line with ENTSO-E's assumptions.\n",
     "\n",
@@ -8203,9 +8203,14 @@
     "        \"costs_markup_factor\"\n",
     "    ] = artificial_shortage_costs_markup_factor\n",
     "    \n",
-    "    artificial_shortage_sources.loc[\n",
-    "        artificial_shortage_sources[\"country\"] == country, \"nominal_value\"\n",
-    "    ] = annual_maxima_of_unmet_residual_load.at[country, \"2020\"]"
+    "    if country != \"IT\":\n",
+    "        artificial_shortage_sources.loc[\n",
+    "            artificial_shortage_sources[\"country\"] == country, \"nominal_value\"\n",
+    "        ] = annual_maxima_of_unmet_residual_load.at[country, \"2020\"]\n",
+    "    else:\n",
+    "        artificial_shortage_sources.loc[\n",
+    "            artificial_shortage_sources[\"country\"] == country, \"nominal_value\"\n",
+    "        ] = annual_maxima_of_unmet_residual_load.at[country, \"2025\"]"
    ]
   },
   {
@@ -8220,6 +8225,9 @@
     "        annual_maxima_of_unmet_residual_load[\"2020\"] > 0,\n",
     "        annual_maxima_of_unmet_residual_load[col].div(annual_maxima_of_unmet_residual_load[\"2020\"]),\n",
     "        0\n",
+    "    )\n",
+    "    artificial_shortage_sources_max_ts.loc[\"IT\", f\"{col}-01-01\"] = (\n",
+    "        annual_maxima_of_unmet_residual_load.loc[\"IT\", col] / annual_maxima_of_unmet_residual_load.loc[\"IT\", \"2025\"]\n",
     "    )\n",
     "artificial_shortage_sources_max_ts = artificial_shortage_sources_max_ts.T"
    ]


### PR DESCRIPTION
For Italy, another approach is required to prevent shortage from happening. Since there is now capacity for 2020 available to be used for normalization, capacity from 2025 is used instead and time series are scaled accordingly.